### PR TITLE
Fix TokenService dependency

### DIFF
--- a/backend/ClinicApi/Services/TokenService.cs
+++ b/backend/ClinicApi/Services/TokenService.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using ClinicApi.Configuration;
 using ClinicApi.Models;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;


### PR DESCRIPTION
## Summary
- add the missing ClinicApi.Configuration namespace import so JwtSettings resolves in TokenService

## Testing
- DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet build *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deffd3c7d0832e8440324d0cc4857f