### PR TITLE
Add Swashbuckle package for Swagger extensions

### DIFF
--- a/backend/ClinicApi/ClinicApi.csproj
+++ b/backend/ClinicApi/ClinicApi.csproj
@@ -17,5 +17,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/backend/ClinicApi/Endpoints/AuthEndpoints.cs
+++ b/backend/ClinicApi/Endpoints/AuthEndpoints.cs
@@ -1,6 +1,8 @@
 using ClinicApi.Data;
 using ClinicApi.Dtos;
 using ClinicApi.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 

--- a/backend/ClinicApi/Endpoints/ConsultaEndpoints.cs
+++ b/backend/ClinicApi/Endpoints/ConsultaEndpoints.cs
@@ -1,6 +1,8 @@
 using ClinicApi.Data;
 using ClinicApi.Dtos;
 using ClinicApi.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 

--- a/backend/ClinicApi/Endpoints/MedicoEndpoints.cs
+++ b/backend/ClinicApi/Endpoints/MedicoEndpoints.cs
@@ -1,6 +1,8 @@
 using ClinicApi.Data;
 using ClinicApi.Dtos;
 using ClinicApi.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 

--- a/backend/ClinicApi/Endpoints/PacienteEndpoints.cs
+++ b/backend/ClinicApi/Endpoints/PacienteEndpoints.cs
@@ -1,6 +1,8 @@
 using ClinicApi.Data;
 using ClinicApi.Dtos;
 using ClinicApi.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 

--- a/backend/ClinicApi/Endpoints/UserEndpoints.cs
+++ b/backend/ClinicApi/Endpoints/UserEndpoints.cs
@@ -2,6 +2,8 @@ using ClinicApi.Data;
 using ClinicApi.Dtos;
 using ClinicApi.Models;
 using ClinicApi.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 

--- a/backend/ClinicApi/Services/TokenService.cs
+++ b/backend/ClinicApi/Services/TokenService.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using ClinicApi.Configuration;
 using ClinicApi.Models;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;


### PR DESCRIPTION
## Summary
- add the Swashbuckle.AspNetCore package reference so the AddSwaggerGen and UseSwagger extension methods resolve

## Testing
- DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet build *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deffd3c7d0832e8440324d0cc4857f