### PR TITLE
Configure CORS and update API URL

### DIFF
--- a/backend/ClinicApi/Program.cs
+++ b/backend/ClinicApi/Program.cs
@@ -34,6 +34,16 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
 builder.Services.AddAuthorization();
 
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowFrontend", policy =>
+    {
+        policy.WithOrigins("http://localhost:5173", "https://localhost:5173")
+              .AllowAnyHeader()
+              .AllowAnyMethod();
+    });
+});
+
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
@@ -66,6 +76,8 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+app.UseCors("AllowFrontend");
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api'
+  baseURL: import.meta.env.VITE_API_URL || 'https://localhost:57761/'
 })
 
 api.interceptors.response.use(


### PR DESCRIPTION
## Summary
- add a CORS policy that allows the Vite development origins in the API
- update the frontend axios client to use the new https://localhost:57761/ base URL by default

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df0716f7a0832e8f30d31f7ce8adab