### PR TITLE
Refine Difarmer login logo

### DIFF
--- a/frontend/src/assets/difarmer-logo.svg
+++ b/frontend/src/assets/difarmer-logo.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 460 140" role="img" aria-labelledby="title desc">
+  <title id="title">Difarmer</title>
+  <desc id="desc">Logotipo de Difarmer con isotipo circular verde y letras en azul</desc>
+  <defs>
+    <linearGradient id="isoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00c389" />
+      <stop offset="100%" stop-color="#0b7cc1" />
+    </linearGradient>
+    <linearGradient id="textGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0a4f8f" />
+      <stop offset="100%" stop-color="#09346a" />
+    </linearGradient>
+    <clipPath id="clipCircle">
+      <circle cx="70" cy="70" r="54" />
+    </clipPath>
+  </defs>
+  <g transform="translate(10 10)">
+    <circle cx="70" cy="70" r="60" fill="url(#isoGradient)" />
+    <g clip-path="url(#clipCircle)">
+      <path d="M70 18c-5.4 0-9.8 4.4-9.8 9.8V62H27.8C22.4 62 18 66.4 18 71.8s4.4 9.8 9.8 9.8H60.2V112c0 5.4 4.4 9.8 9.8 9.8s9.8-4.4 9.8-9.8V81.6h32.4c5.4 0 9.8-4.4 9.8-9.8s-4.4-9.8-9.8-9.8H79.8V27.8C79.8 22.4 75.4 18 70 18z" fill="#ffffff" opacity="0.92" />
+      <path d="M105 32c-18 12-33.8 31.7-37.7 59.4 18.7-2.3 36.6-15.2 47.6-32.2 3.7-5.8 1.7-13.6-4.3-17-1.8-1-3.9-1.5-6-1.4z" fill="rgba(255,255,255,0.85)" />
+    </g>
+  </g>
+  <g transform="translate(160 94)">
+    <text font-family="'Montserrat', 'Poppins', 'Segoe UI', sans-serif" font-size="60" font-weight="600" fill="url(#textGradient)" letter-spacing="1.2">
+      <tspan x="0" y="0">Di</tspan>
+      <tspan x="80" y="0" fill="#00a17a">farmer</tspan>
+    </text>
+  </g>
+</svg>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,40 +1,43 @@
 <template>
   <div class="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-200 to-slate-400">
-    <div class="w-full max-w-md rounded-xl bg-white p-8 shadow-xl">
-      <h1 class="mb-6 text-center text-3xl font-bold text-slate-700">Iniciar sesión</h1>
-      <form @submit.prevent="handleLogin" class="space-y-4">
-        <div>
-          <label for="correo" class="mb-1 block text-sm font-semibold text-slate-600">Correo</label>
-          <input
-            v-model="form.correo"
-            type="text"
-            id="correo"
-            class="w-full rounded-lg border border-slate-300 px-4 py-2 focus:border-indigo-500 focus:outline-none"
-            placeholder="usuario"
-            required
-          />
-        </div>
-        <div>
-          <label for="password" class="mb-1 block text-sm font-semibold text-slate-600">Contraseña</label>
-          <input
-            v-model="form.password"
-            type="password"
-            id="password"
-            class="w-full rounded-lg border border-slate-300 px-4 py-2 focus:border-indigo-500 focus:outline-none"
-            placeholder="••••••"
-            required
-          />
-        </div>
-        <p v-if="error" class="text-sm text-red-600">{{ error }}</p>
-        <button
-          type="submit"
-          class="w-full rounded-lg bg-indigo-600 py-2 text-white transition hover:bg-indigo-700"
-          :disabled="loading"
-        >
-          <span v-if="loading">Validando...</span>
-          <span v-else>Entrar</span>
-        </button>
-      </form>
+    <div class="flex w-full max-w-md flex-col items-center">
+      <img :src="difarmerLogo" alt="Difarmer" class="mb-6 w-48 drop-shadow" />
+      <div class="w-full rounded-xl bg-white p-8 shadow-xl">
+        <h1 class="mb-6 text-center text-3xl font-bold text-slate-700">Iniciar sesión</h1>
+        <form @submit.prevent="handleLogin" class="space-y-4">
+          <div>
+            <label for="correo" class="mb-1 block text-sm font-semibold text-slate-600">Correo</label>
+            <input
+              v-model="form.correo"
+              type="text"
+              id="correo"
+              class="w-full rounded-lg border border-slate-300 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+              placeholder="usuario"
+              required
+            />
+          </div>
+          <div>
+            <label for="password" class="mb-1 block text-sm font-semibold text-slate-600">Contraseña</label>
+            <input
+              v-model="form.password"
+              type="password"
+              id="password"
+              class="w-full rounded-lg border border-slate-300 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+              placeholder="••••••"
+              required
+            />
+          </div>
+          <p v-if="error" class="text-sm text-red-600">{{ error }}</p>
+          <button
+            type="submit"
+            class="w-full rounded-lg bg-indigo-600 py-2 text-white transition hover:bg-indigo-700"
+            :disabled="loading"
+          >
+            <span v-if="loading">Validando...</span>
+            <span v-else>Entrar</span>
+          </button>
+        </form>
+      </div>
     </div>
   </div>
 </template>
@@ -43,6 +46,7 @@
 import { reactive, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
+import difarmerLogo from '../assets/difarmer-logo.svg'
 
 const router = useRouter()
 const auth = useAuthStore()


### PR DESCRIPTION
## Summary
- replace the placeholder Difarmer SVG with a more faithful recreation of the provided artwork for the login screen

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df1a4c76c4832e97c394ecfccd0b86