### PR TITLE
Enable editing and confirm deletions in admin panel

### DIFF
--- a/frontend/src/views/AdministracionView.vue
+++ b/frontend/src/views/AdministracionView.vue
@@ -14,14 +14,26 @@
       <section class="rounded-2xl bg-white p-6 shadow">
         <h2 class="text-lg font-semibold text-slate-700">Usuarios</h2>
         <div class="mt-4 grid gap-6 lg:grid-cols-[320px_1fr]">
-          <form @submit.prevent="createUser" class="space-y-4">
+          <form @submit.prevent="submitUser" class="space-y-4">
             <div>
               <label class="mb-1 block text-sm font-medium text-slate-600">Correo</label>
-              <input v-model="userForm.correo" class="w-full rounded-lg border border-slate-300 px-3 py-2" required />
+              <input
+                v-model="userForm.correo"
+                :disabled="Boolean(editingUserId)"
+                :required="!editingUserId"
+                class="w-full rounded-lg border border-slate-300 px-3 py-2 disabled:cursor-not-allowed disabled:bg-slate-100"
+              />
+              <p v-if="editingUserId" class="mt-1 text-xs text-slate-500">El correo no se puede modificar.</p>
             </div>
             <div>
               <label class="mb-1 block text-sm font-medium text-slate-600">Contraseña</label>
-              <input v-model="userForm.password" type="password" class="w-full rounded-lg border border-slate-300 px-3 py-2" required />
+              <input
+                v-model="userForm.password"
+                :required="!editingUserId"
+                type="password"
+                class="w-full rounded-lg border border-slate-300 px-3 py-2"
+              />
+              <p v-if="editingUserId" class="mt-1 text-xs text-slate-500">Deja en blanco para mantener la contraseña actual.</p>
             </div>
             <div>
               <label class="mb-1 block text-sm font-medium text-slate-600">Nombre completo</label>
@@ -40,7 +52,19 @@
               <input type="checkbox" v-model="userForm.activo" class="rounded border-slate-300" /> Activo
             </label>
             <p v-if="userError" class="text-sm text-red-600">{{ userError }}</p>
-            <button type="submit" class="w-full rounded-lg bg-indigo-600 py-2 text-white hover:bg-indigo-700">Crear usuario</button>
+            <div class="flex flex-col gap-2 sm:flex-row">
+              <button type="submit" class="flex-1 rounded-lg bg-indigo-600 py-2 text-white hover:bg-indigo-700">
+                {{ editingUserId ? 'Actualizar usuario' : 'Crear usuario' }}
+              </button>
+              <button
+                v-if="editingUserId"
+                type="button"
+                class="flex-1 rounded-lg border border-slate-300 py-2 text-slate-600 hover:bg-slate-100"
+                @click="cancelUserEdit"
+              >
+                Cancelar
+              </button>
+            </div>
           </form>
 
           <div class="overflow-x-auto">
@@ -70,7 +94,10 @@
                     </span>
                   </td>
                   <td class="px-4 py-2 text-center">
-                    <button class="text-sm text-rose-600 hover:underline" @click="deleteUser(usuario.id)">Eliminar</button>
+                    <div class="flex items-center justify-center gap-4">
+                      <button class="text-sm text-indigo-600 hover:underline" @click="startEditUser(usuario)">Editar</button>
+                      <button class="text-sm text-rose-600 hover:underline" @click="deleteUser(usuario.id)">Eliminar</button>
+                    </div>
                   </td>
                 </tr>
                 <tr v-if="!usuarios.length">
@@ -85,7 +112,7 @@
       <section class="rounded-2xl bg-white p-6 shadow">
         <h2 class="text-lg font-semibold text-slate-700">Médicos</h2>
         <div class="mt-4 grid gap-6 lg:grid-cols-[320px_1fr]">
-          <form @submit.prevent="createMedico" class="space-y-4">
+          <form @submit.prevent="submitMedico" class="space-y-4">
             <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
                 <label class="mb-1 block text-sm font-medium text-slate-600">Primer nombre</label>
@@ -126,7 +153,19 @@
               <input type="checkbox" v-model="medicoForm.activo" class="rounded border-slate-300" /> Activo
             </label>
             <p v-if="medicoError" class="text-sm text-red-600">{{ medicoError }}</p>
-            <button type="submit" class="w-full rounded-lg bg-indigo-600 py-2 text-white hover:bg-indigo-700">Registrar médico</button>
+            <div class="flex flex-col gap-2 sm:flex-row">
+              <button type="submit" class="flex-1 rounded-lg bg-indigo-600 py-2 text-white hover:bg-indigo-700">
+                {{ editingMedicoId ? 'Actualizar médico' : 'Registrar médico' }}
+              </button>
+              <button
+                v-if="editingMedicoId"
+                type="button"
+                class="flex-1 rounded-lg border border-slate-300 py-2 text-slate-600 hover:bg-slate-100"
+                @click="cancelMedicoEdit"
+              >
+                Cancelar
+              </button>
+            </div>
           </form>
 
           <div class="overflow-x-auto">
@@ -156,9 +195,14 @@
                     </span>
                   </td>
                   <td class="px-4 py-2 text-center">
-                    <button class="text-sm text-rose-600 hover:underline" @click="deleteMedico(medico.id)">
-                      Eliminar
-                    </button>
+                    <div class="flex items-center justify-center gap-4">
+                      <button class="text-sm text-indigo-600 hover:underline" @click="startEditMedico(medico)">
+                        Editar
+                      </button>
+                      <button class="text-sm text-rose-600 hover:underline" @click="deleteMedico(medico.id)">
+                        Eliminar
+                      </button>
+                    </div>
                   </td>
                 </tr>
                 <tr v-if="!medicos.length">
@@ -172,7 +216,7 @@
       <section class="rounded-2xl bg-white p-6 shadow">
         <h2 class="text-lg font-semibold text-slate-700">Pacientes</h2>
         <div class="mt-4 grid gap-6 lg:grid-cols-[320px_1fr]">
-          <form @submit.prevent="createPaciente" class="space-y-4">
+          <form @submit.prevent="submitPaciente" class="space-y-4">
             <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
                 <label class="mb-1 block text-sm font-medium text-slate-600">Primer nombre</label>
@@ -199,9 +243,19 @@
               <input type="checkbox" v-model="pacienteForm.activo" class="rounded border-slate-300" /> Activo
             </label>
             <p v-if="pacienteError" class="text-sm text-red-600">{{ pacienteError }}</p>
-            <button type="submit" class="w-full rounded-lg bg-indigo-600 py-2 text-white hover:bg-indigo-700">
-              Registrar paciente
-            </button>
+            <div class="flex flex-col gap-2 sm:flex-row">
+              <button type="submit" class="flex-1 rounded-lg bg-indigo-600 py-2 text-white hover:bg-indigo-700">
+                {{ editingPacienteId ? 'Actualizar paciente' : 'Registrar paciente' }}
+              </button>
+              <button
+                v-if="editingPacienteId"
+                type="button"
+                class="flex-1 rounded-lg border border-slate-300 py-2 text-slate-600 hover:bg-slate-100"
+                @click="cancelPacienteEdit"
+              >
+                Cancelar
+              </button>
+            </div>
           </form>
 
           <div class="overflow-x-auto">
@@ -229,7 +283,12 @@
                     </span>
                   </td>
                   <td class="px-4 py-2 text-center">
-                    <button class="text-sm text-rose-600 hover:underline" @click="deletePaciente(paciente.id)">Eliminar</button>
+                    <div class="flex items-center justify-center gap-4">
+                      <button class="text-sm text-indigo-600 hover:underline" @click="startEditPaciente(paciente)">
+                        Editar
+                      </button>
+                      <button class="text-sm text-rose-600 hover:underline" @click="deletePaciente(paciente.id)">Eliminar</button>
+                    </div>
                   </td>
                 </tr>
                 <tr v-if="!pacientes.length">
@@ -280,6 +339,9 @@ const pacienteForm = reactive({
   telefono: '',
   activo: true
 })
+const editingUserId = ref(null)
+const editingMedicoId = ref(null)
+const editingPacienteId = ref(null)
 
 const ensureAuth = () => {
   if (!auth.isAuthenticated) {
@@ -340,55 +402,137 @@ const resetPacienteForm = () => {
   pacienteForm.activo = true
 }
 
-const createUser = async () => {
+const submitUser = async () => {
   userError.value = ''
   try {
-    const payload = {
-      ...userForm,
-      medicoId: userForm.medicoId ? Number(userForm.medicoId) : null
+    if (editingUserId.value) {
+      await api.put(`/usuarios/${editingUserId.value}`, {
+        password: userForm.password ? userForm.password : null,
+        nombreCompleto: userForm.nombreCompleto,
+        medicoId: userForm.medicoId ? Number(userForm.medicoId) : null,
+        activo: userForm.activo
+      })
+      editingUserId.value = null
+    } else {
+      await api.post('/usuarios', {
+        ...userForm,
+        medicoId: userForm.medicoId ? Number(userForm.medicoId) : null
+      })
     }
-    await api.post('/usuarios', payload)
+
     resetUserForm()
     await fetchUsuarios()
   } catch (err) {
-    userError.value = err.response?.data ?? 'No se pudo crear el usuario.'
+    userError.value = err.response?.data ?? 'No se pudo guardar el usuario.'
   }
 }
 
-const createMedico = async () => {
+const submitMedico = async () => {
   medicoError.value = ''
   try {
-    await api.post('/medicos', { ...medicoForm })
+    if (editingMedicoId.value) {
+      await api.put(`/medicos/${editingMedicoId.value}`, { ...medicoForm })
+      editingMedicoId.value = null
+    } else {
+      await api.post('/medicos', { ...medicoForm })
+    }
+
     resetMedicoForm()
     await fetchMedicos()
+    await fetchUsuarios()
   } catch (err) {
-    medicoError.value = err.response?.data ?? 'No se pudo registrar el médico.'
+    medicoError.value = err.response?.data ?? 'No se pudo guardar el médico.'
   }
 }
 
-const createPaciente = async () => {
+const submitPaciente = async () => {
   pacienteError.value = ''
   try {
-    await api.post('/pacientes', { ...pacienteForm })
+    if (editingPacienteId.value) {
+      await api.put(`/pacientes/${editingPacienteId.value}`, { ...pacienteForm })
+      editingPacienteId.value = null
+    } else {
+      await api.post('/pacientes', { ...pacienteForm })
+    }
+
     resetPacienteForm()
     await fetchPacientes()
   } catch (err) {
-    pacienteError.value = err.response?.data ?? 'No se pudo registrar el paciente.'
+    pacienteError.value = err.response?.data ?? 'No se pudo guardar el paciente.'
   }
 }
 
+const startEditUser = usuario => {
+  editingUserId.value = usuario.id
+  userForm.correo = usuario.correo
+  userForm.password = ''
+  userForm.nombreCompleto = usuario.nombreCompleto
+  userForm.medicoId = usuario.medicoId ?? null
+  userForm.activo = usuario.activo
+}
+
+const cancelUserEdit = () => {
+  editingUserId.value = null
+  resetUserForm()
+}
+
+const startEditMedico = medico => {
+  editingMedicoId.value = medico.id
+  medicoForm.primerNombre = medico.primerNombre
+  medicoForm.segundoNombre = medico.segundoNombre ?? ''
+  medicoForm.apellidoPaterno = medico.apellidoPaterno
+  medicoForm.apellidoMaterno = medico.apellidoMaterno
+  medicoForm.cedula = medico.cedula
+  medicoForm.telefono = medico.telefono
+  medicoForm.especialidad = medico.especialidad
+  medicoForm.email = medico.email
+  medicoForm.activo = medico.activo
+}
+
+const cancelMedicoEdit = () => {
+  editingMedicoId.value = null
+  resetMedicoForm()
+}
+
+const startEditPaciente = paciente => {
+  editingPacienteId.value = paciente.id
+  pacienteForm.primerNombre = paciente.primerNombre
+  pacienteForm.segundoNombre = paciente.segundoNombre ?? ''
+  pacienteForm.apellidoPaterno = paciente.apellidoPaterno
+  pacienteForm.apellidoMaterno = paciente.apellidoMaterno
+  pacienteForm.telefono = paciente.telefono
+  pacienteForm.activo = paciente.activo
+}
+
+const cancelPacienteEdit = () => {
+  editingPacienteId.value = null
+  resetPacienteForm()
+}
+
 const deleteUser = async id => {
+  if (!confirm('¿Deseas eliminar este usuario?')) {
+    return
+  }
+
   await api.delete(`/usuarios/${id}`)
   await fetchUsuarios()
 }
 
 const deleteMedico = async id => {
+  if (!confirm('¿Deseas eliminar este médico?')) {
+    return
+  }
+
   await api.delete(`/medicos/${id}`)
   await fetchMedicos()
   await fetchUsuarios()
 }
 
 const deletePaciente = async id => {
+  if (!confirm('¿Deseas eliminar este paciente?')) {
+    return
+  }
+
   await api.delete(`/pacientes/${id}`)
   await fetchPacientes()
 }


### PR DESCRIPTION
## Summary
- allow updating existing usuarios, médicos y pacientes desde la vista de administración reutilizando los formularios actuales
- añadir acciones de edición y cancelación en las tablas y avisos en los campos cuando no se puede cambiar un dato
- solicitar confirmación antes de eliminar usuarios, médicos o pacientes para evitar borrados accidentales

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df20b5a224832ebd86a4aa6d4e063a